### PR TITLE
Added arm64 support in travis-ci :

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,34 @@ jobs:
       os: linux 
       dist: xenial
     - stage: lint and test
+      name: lint
+      arch : arm64
+      script:
+        - sudo apt-get update
+        - sudo apt-get install shellcheck
+        - make lint
+        - make tidy-check
+        - make generate-check
+        - shellcheck script/*.sh
+        - shellcheck .travis/*.sh
+      # linting is OS agnostic but protobuf_verify needs utils to lets be explicit
+      # about its runtime environment
+      os: linux
+      dist: xenial
+    - stage: lint and test
       name: macos tests
       script:
         - .travis/run-unit-tests.sh
       os: macos
     - stage: lint and test
       name: linux tests
+      script:
+        - .travis/run-unit-tests.sh
+      os: linux
+      dist: xenial
+    - stage: lint and test
+      name: linux tests
+      arch: arm64
       script:
         - .travis/run-unit-tests.sh
       os: linux
@@ -84,7 +106,34 @@ jobs:
           on:
             tags: true
             condition: $GITHUB_TOKEN != ""
-
+    - stage: build release
+      arch: arm64
+      script:
+        - make artifact
+        - .travis/build-release.sh
+      os: linux
+      dist: xenial
+      deploy:
+        - provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: scytale-artifacts
+          local-dir: artifacts
+          upload-dir: spire
+          acl: public_read
+          skip_cleanup: true
+          region: us-east-2
+          on:
+            all_branches: true
+            condition: $AWS_SECRET_ACCESS_KEY != ""
+        - provider: releases
+          api_key: $GITHUB_TOKEN
+          file_glob: true
+          file: releases/*
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: $GITHUB_TOKEN != ""
     - stage: publish images
       if: type = push AND (tag IS present OR branch = master)
       os: linux
@@ -96,7 +145,19 @@ jobs:
         - make images
         - make integration
         - .travis/publish-images.sh
-
+    - stage: publish images
+      arch: arm64
+      if: type = push AND (tag IS present OR branch = master)
+      os: linux
+      dist: xenial
+      before_script:
+        # Decrypt credentials needed to log into gcr registry
+        - echo $encrypted_b48f9e852489_iv
+        - openssl aes-256-cbc -K $encrypted_b48f9e852489_key -iv $encrypted_b48f9e852489_iv -in .travis/spire-travis-ci.json.enc -out .travis/spire-travis-ci.json -d
+      script:
+        - make images
+        - make integration
+        - .travis/publish-images.sh
     - stage: nightly integration tests
       if: type = cron
       os: linux

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ endif
 arch1=$(shell uname -m)
 ifeq ($(arch1),x86_64)
 arch2=amd64
+else ifeq ($(arch1),aarch64)
+arch2=arm64
 else
 $(error unsupported ARCH: $(arch1))
 endif
@@ -100,7 +102,11 @@ golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 
 protoc_version = 3.11.1
+ifeq ($(arch1),aarch64)
+protoc_url = https://github.com/protocolbuffers/protobuf/releases/download/v$(protoc_version)/protoc-$(protoc_version)-$(os2)-aarch_64.zip
+else
 protoc_url = https://github.com/protocolbuffers/protobuf/releases/download/v$(protoc_version)/protoc-$(protoc_version)-$(os2)-$(arch1).zip
+endif
 protoc_dir = $(build_dir)/protoc/$(protoc_version)
 protoc_bin = $(protoc_dir)/bin/protoc
 


### PR DESCRIPTION
Hi

**Package Owner:** Rahul Aggarwal
**PR change Details:**
       **Patch Details :**   Following 2 files have been modified : 
1. .travis.yml :  All test jobs are duplicated for arm64 testing. For test case :: ' stage: "lint and test" / name : "test" ', shellcheck package has been installed.
2. Makefile : Only amd64 specific binaries for 'protobuf' were getting downloaded. So, added aarch64 platform in Makefile and added if statement to download binaries for aarch_64 platform as well.
**Testing Detail :**  
Please find my travis-ci testing jobs here :  https://travis-ci.com/github/rahulgit-ps/spire
Test stage for "Publish Images" is getting failed on both amd64 and arm64 platforms. This test case is doing decryption work using encrypted key.  Test is failing because there is an encryption key, which is only available to main branch owner. As I have forked the project, that key is not available to me, hence this test case will fail for that. However, it does not contain platform specific code. 
     Reviewer Comment : < To be filled by Reviewer >
**PR Description :**  Here is my commit message : 
Added arm64 jobs in .travis.yml for all test cases.
Added arm64 support in Makefile, for downloading protobuff releases specific to  aarch_64 platform. 
     Reviewer Comment : < To be filled by Reviewer >
**Peer Reviewer:** N/A                                                                 
**Reviewer:**  Rajeev Nayan
 
Thanks
Rahul Aggarwal